### PR TITLE
RTCM Raise Error if more data is needed than is in the payload

### DIFF
--- a/examples/rtcmfile.py
+++ b/examples/rtcmfile.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     filename = input().strip('"')
     print(
         "How do you want to handle protocol errors?",
-        "(0 = ignore, 1 = log and continue, 3 = raise and stop) (1) ",
+        "(0 = ignore, 1 = log and continue, 2 = raise and stop) (1) ",
         end="",
     )
     val = input() or "1"

--- a/pyrtcm/rtcmmessage.py
+++ b/pyrtcm/rtcmmessage.py
@@ -177,6 +177,20 @@ class RTCMMessage:
         else:
             atts = attsiz(att)
         bitfield = self._payload_bits[offset : offset + atts]
+
+        if len(bitfield) != atts:
+            """
+            This should never happen as it is showing that we tried to use more data than
+            was in the payload. This could be a malformed packet or a parsing error in pyrtcm.
+            This is not a security issue as python does not allow for access outside of the
+            buffer.
+            A partial message will not be returned, previously all the remaining attributes
+            would have been returned as 0
+            """
+
+            raise rte.RTCMParseError("Payload is too small, it doesn't contain enough for all expected data.")
+
+
         val = bits2val(att, scale, bitfield)
 
         setattr(self, keyr, val)


### PR DESCRIPTION
A partial message will not be returned, previously all the remaining attributes would have been returned as 0.

This change makes it that some tests fail, (GPS MSM processing) since they were passing due to the side effect of fields without data in the payload being returned as 0's. .

Also fixed the rtcmfile.py, it said enter 3 for raise and stop, ERR_RAISE is 2 not 3.

# pyrtcm Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context and, where applicable, any RTCM documentation sources you have used. List any dependencies that are required for this change.

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [ ] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my RTCM documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
