### PR TITLE
fixes: #28 DF408 Scaling is incorrect

### DIFF
--- a/src/pyrtcm/rtcmtypes_core.py
+++ b/src/pyrtcm/rtcmtypes_core.py
@@ -501,7 +501,7 @@ RTCM_DATA_FIELDS = {
         0,
         "GNSS PhaseRange Lock Time Indicator with extended range and resolution.",
     ),
-    "DF408": (UINT10, P2_P4, "GNSS signal CNR with extended resolution"),
+    "DF408": (UINT10, P2_4, "GNSS signal CNR with extended resolution"),
     "DF409": (UINT3, 1, "IODS - Issue Of Data Station"),
     # 'DF410': RESERVED,
     "DF411": (UINT2, 0, "Clock Steering Indicator"),


### PR DESCRIPTION
Scaling for DF408 was going the wrong way.

# pyrtcm Pull Request Template

## Description

DF408 Scaling was making the values larger instead of smaller.

See issue #28  for more of the details 

Fixes # (issue)

#28 

## Testing

Sample included in the issue. tests/*.py ran manually.

## Checklist:

- [X] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [X] I have performed a self-review of my own code.
- [X] (*if appropriate*) I have cited my RTCM documentation source(s).
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [ N/A ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [X ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [X ] My changes generate no new warnings.
- [X ] Any dependent changes have been merged and published in downstream modules.
- [ X] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [X ] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
