### PR TITLE
fix KeyError with undefined msg Fixes #33

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Fixes # (issue)
 
 ## Testing
 
-Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python pytest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
+Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
 
 - [ ] Test A
 - [ ] Test B

--- a/src/pyrtcm/rtcmmessage.py
+++ b/src/pyrtcm/rtcmmessage.py
@@ -259,12 +259,12 @@ class RTCMMessage:
         # if MSM message and labelmsm flag is set,
         # label NSAT and NCELL group attributes with
         # corresponding satellite PRN and signal ID
-        if not self._unknown and self._labelmsm and "MSM" in RTCM_MSGIDS[self.identity]:
-            sats = sat2prn(self)
-            cells = cell2prn(self)
-            is_msm = True
-        else:
-            is_msm = False
+        is_msm = False
+        if not self._unknown:
+            if self._labelmsm and "MSM" in RTCM_MSGIDS[self.identity]:
+                sats = sat2prn(self)
+                cells = cell2prn(self)
+                is_msm = True
 
         stg = f"<RTCM({self.identity}, "
         for i, att in enumerate(self.__dict__):

--- a/src/pyrtcm/rtcmmessage.py
+++ b/src/pyrtcm/rtcmmessage.py
@@ -259,7 +259,7 @@ class RTCMMessage:
         # if MSM message and labelmsm flag is set,
         # label NSAT and NCELL group attributes with
         # corresponding satellite PRN and signal ID
-        if self._labelmsm and "MSM" in RTCM_MSGIDS[self.identity]:
+        if not self._unknown and self._labelmsm and "MSM" in RTCM_MSGIDS[self.identity]:
             sats = sat2prn(self)
             cells = cell2prn(self)
             is_msm = True

--- a/tests/test_specialcases.py
+++ b/tests/test_specialcases.py
@@ -11,7 +11,7 @@ import os
 import unittest
 from collections import namedtuple
 
-from pyrtcm import RTCMReader, RTCMTypeError
+from pyrtcm import RTCMMessage, RTCMReader, RTCMTypeError
 from pyrtcm.rtcmhelpers import cell2prn, sat2prn, id2prnsigmap
 
 
@@ -182,6 +182,19 @@ class SpecialTest(unittest.TestCase):
                 if raw is not None:
                     if parsed.identity in ["1230"]:
                         res = str(cell2prn(parsed))
+
+    def testunknown(self):  # test (synthetic) unknown messages
+        EXPECTED_RESULTS = [
+            "<RTCM(4062, DF002=4062, Not_Yet_Implemented)>",
+            "<RTCM(999, DF002=999, Not_Yet_Implemented)>",
+        ]
+        PAYLOADS = [
+            b"\xfd\xe1\x81\xc9\x84\x00\x08\xc2\xb8\x88\x00\x38\x80\x09\xd0\x46\x00\x28",
+            b"\x3e\x71\x81\xc9\x84\x00\x08\xc2\xb8\x88\x00\x38\x80\x09\xd0\x46\x00\x28",
+        ]
+        for i, pay in enumerate(PAYLOADS):
+            msg = RTCMMessage(payload=pay)
+            self.assertEqual(str(msg), EXPECTED_RESULTS[i])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

Fixes issue reported by @wdc-rsat against PyGPSClient library where undefined RTCM message types cause a KeyError failure.

Fixes #33

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] add testunknown to test_specialcases.py

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my RTCM documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
