### PR TITLE
Remove python 3.7

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.8"
+    "moduleversion": "1.0.9"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -78,6 +78,19 @@
             "problemMatcher": []
         },
         {
+            "label": "Sort Imports",
+            "type": "process",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "isort",
+                "src",
+                "--jobs",
+                "-1"
+            ],
+            "problemMatcher": []
+        },
+        {
             "label": "Format",
             "type": "process",
             "command": "${config:python.defaultInterpreterPath}",
@@ -210,6 +223,7 @@
                 "Install Test Dependencies",
                 "Install Dependencies",
                 "Security",
+                "Sort Imports",
                 "Format",
                 "Pylint",
                 "Test",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you're adding or amending rtcm payload definitions or configuration database 
 ## Coding conventions
 
 * This is open source software. Code should be as simple and transparent as possible. Favour clarity over brevity.
-* The code should be compatible with Python >=3.7.
+* The code should be compatible with Python >=3.8.
 * The core code should be as generic and reusable as possible. We endeavour to limit the amount of processing dedicated to specific rtcm message types, though this is sometimes unavoidable.
 * Avoid external library dependencies unless there's a compelling reason not to.
 * We use and recommend [Visual Studio Code](https://code.visualstudio.com/) with the [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for development and testing.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Contributions welcome - please refer to [CONTRIBUTING.MD](https://github.com/sem
 ---
 ## <a name="installation">Installation</a>
 
-`pyrtcm` is compatible with Python >=3.7 and has no third-party library dependencies.
+`pyrtcm` is compatible with Python >=3.8 and has no third-party library dependencies.
 
 In the following, `python` & `pip` refer to the Python 3 executables. You may need to type 
 `python3` or `pip3`, depending on your particular environment.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # pyrtcm Release Notes
 
-### RELEASE CANDIDATE 1.0.8
+### RELEASE CANDIDATE 1.0.9
+
+1. Remove Python 3.7 from workflows.
+
+### RELEASE 1.0.8
 
 FIXES:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "RTCM3 protocol parser"
-version = "1.0.8"
+version = "1.0.9"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -64,8 +63,11 @@ test = [
 ]
 
 [tool.black]
-line-length = 88
-target-version = ['py37']
+target-version = ['py38']
+
+[tool.isort]
+py_version = 38
+profile = "black"
 
 [tool.bandit]
 exclude_dirs = ["docs", "examples", "tests"]
@@ -75,7 +77,7 @@ skips = []
 jobs = 0
 reports = "y"
 recursive = "y"
-py-version = "3.7"
+py-version = "3.8"
 fail-under = "9.8"
 fail-on = "E,F"
 clear-cache-post-run = "y"

--- a/src/pyrtcm/__init__.py
+++ b/src/pyrtcm/__init__.py
@@ -7,19 +7,18 @@ Created on 14 Feb 2022
 """
 
 from pyrtcm._version import __version__
-
 from pyrtcm.exceptions import (
+    ParameterError,
     RTCMMessageError,
     RTCMParseError,
-    RTCMTypeError,
     RTCMStreamError,
-    ParameterError,
+    RTCMTypeError,
 )
+from pyrtcm.rtcmhelpers import *
 from pyrtcm.rtcmmessage import RTCMMessage
 from pyrtcm.rtcmreader import RTCMReader
-from pyrtcm.socket_stream import SocketStream
 from pyrtcm.rtcmtypes_core import *
 from pyrtcm.rtcmtypes_get import *
-from pyrtcm.rtcmhelpers import *
+from pyrtcm.socket_stream import SocketStream
 
 version = __version__  # pylint: disable=invalid-name

--- a/src/pyrtcm/_version.py
+++ b/src/pyrtcm/_version.py
@@ -8,4 +8,4 @@ Created on 14 Feb 2022
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/src/pyrtcm/rtcmhelpers.py
+++ b/src/pyrtcm/rtcmhelpers.py
@@ -11,24 +11,25 @@ Created on 14 Feb 2022
 # pylint: disable=invalid-name
 
 from datetime import datetime, timedelta
-from pyrtcm.rtcmtypes_core import RTCM_DATA_FIELDS, RTCM_MSGIDS
+
 from pyrtcm.exceptions import RTCMTypeError
 from pyrtcm.rtcmtables import (
-    GPS_PRN_MAP,
-    GPS_SIG_MAP,
-    GLONASS_PRN_MAP,
-    GLONASS_SIG_MAP,
-    GALILEO_PRN_MAP,
-    GALILEO_SIG_MAP,
-    SBAS_PRN_MAP,
-    SBAS_SIG_MAP,
-    QZSS_PRN_MAP,
-    QZSS_SIG_MAP,
     BEIDOU_PRN_MAP,
     BEIDOU_SIG_MAP,
+    GALILEO_PRN_MAP,
+    GALILEO_SIG_MAP,
+    GLONASS_PRN_MAP,
+    GLONASS_SIG_MAP,
+    GPS_PRN_MAP,
+    GPS_SIG_MAP,
     IRNSS_PRN_MAP,
     IRNSS_SIG_MAP,
+    QZSS_PRN_MAP,
+    QZSS_SIG_MAP,
+    SBAS_PRN_MAP,
+    SBAS_SIG_MAP,
 )
+from pyrtcm.rtcmtypes_core import RTCM_DATA_FIELDS, RTCM_MSGIDS
 
 SCALEDP = 8
 

--- a/src/pyrtcm/rtcmmessage.py
+++ b/src/pyrtcm/rtcmmessage.py
@@ -10,33 +10,33 @@ Created on 14 Feb 2022
 # pylint: disable=invalid-name
 
 import pyrtcm.exceptions as rte
+import pyrtcm.rtcmtypes_get as rtg
+from pyrtcm.rtcmhelpers import (
+    att2idx,
+    att2name,
+    attsiz,
+    bits2val,
+    cell2prn,
+    crc2bytes,
+    escapeall,
+    len2bytes,
+    num_setbits,
+    sat2prn,
+)
 from pyrtcm.rtcmtypes_core import (
-    RTCM_HDR,
-    RTCM_MSGIDS,
-    RTCM_DATA_FIELDS,
-    BOOL_GROUPS,
-    ATT_NSAT,
     ATT_NCELL,
-    NSAT,
-    NSIG,
+    ATT_NSAT,
+    BOOL_GROUPS,
     NCELL,
     NL1CA,
     NL1P,
     NL2CA,
     NL2P,
-)
-import pyrtcm.rtcmtypes_get as rtg
-from pyrtcm.rtcmhelpers import (
-    crc2bytes,
-    len2bytes,
-    bits2val,
-    attsiz,
-    num_setbits,
-    sat2prn,
-    cell2prn,
-    att2idx,
-    att2name,
-    escapeall,
+    NSAT,
+    NSIG,
+    RTCM_DATA_FIELDS,
+    RTCM_HDR,
+    RTCM_MSGIDS,
 )
 
 

--- a/src/pyrtcm/rtcmreader.py
+++ b/src/pyrtcm/rtcmreader.py
@@ -22,11 +22,12 @@ Created on 14 Feb 2022
 """
 
 from socket import socket
+
+import pyrtcm.exceptions as rte
+import pyrtcm.rtcmtypes_core as rtt
+from pyrtcm.rtcmhelpers import calc_crc24q
 from pyrtcm.rtcmmessage import RTCMMessage
 from pyrtcm.socket_stream import SocketStream
-from pyrtcm.rtcmhelpers import calc_crc24q
-import pyrtcm.rtcmtypes_core as rtt
-import pyrtcm.exceptions as rte
 
 
 class RTCMReader:

--- a/src/pyrtcm/rtcmtypes_get.py
+++ b/src/pyrtcm/rtcmtypes_get.py
@@ -9,15 +9,7 @@ Information sourced from RTCM STANDARD 10403.3 © 2016 RTCM
 """
 # pylint: disable=too-many-lines, line-too-long
 
-from pyrtcm.rtcmtypes_core import (
-    NSAT,
-    NCELL,
-    NL1CA,
-    NL1P,
-    NL2CA,
-    NL2P,
-    NRES,
-)
+from pyrtcm.rtcmtypes_core import NCELL, NL1CA, NL1P, NL2CA, NL2P, NRES, NSAT
 
 # *************************************************************
 # MSM MESSAGE SUB-SECTION DEFINITIONS


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

Python 3.7 is officially end of life on 27 June 2023. This change removes Python 3.7 from workflows and documentation.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my RTCM documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
