### PR TITLE
fix qzss field size

### DIFF
--- a/src/pyrtcm/rtcmtypes_core.py
+++ b/src/pyrtcm/rtcmtypes_core.py
@@ -549,7 +549,7 @@ RTCM_DATA_FIELDS = {
     "DF451": (BIT2, 1, "QZSS Codes on L2 Channel"),
     "DF452": (UINT10, 1, "QZSS Week Number"),
     "DF453": (UINT4, 0, "QZSS URA"),
-    "DF454": (UINT16, 1, "QZSS SV health"),
+    "DF454": (UINT6, 1, "QZSS SV health"),
     "DF455": (INT8, P2_31, "QZSS TGD"),
     "DF456": (UINT10, 1, "QZSS IODC"),
     "DF457": (BIT1, 1, "QZSS Fit Interval"),


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

Parsing of QZSS msg 1044 fails so I did a small research and there was a typo in datatype for DF454.
I can't afford buying standard but other projects here on github use uint6 for SV health field and this Chinese paper (looks like a valid standard description) also mentions uint6:
http://www.beidou.gov.cn/zt/bdbz/202208/W020220802734047940209.pdf

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Test A
- [x] Test B

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my RTCM documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
