### PR TITLE
Fixed Typo - `GPS INT,eger L1 Pseudorange Modulus Ambiguity`

### DIFF
--- a/src/pyrtcm/rtcmtypes_core.py
+++ b/src/pyrtcm/rtcmtypes_core.py
@@ -125,7 +125,7 @@ RTCM_DATA_FIELDS = {
     "DF011": (UINT, 24, 0.02, "GPS L1 Pseudorange"),
     "DF012": (INT, 20, 0.0005, "GPS L1 PhaseRange - L1 Pseudorange"),
     "DF013": (UINT, 7, 0, "GPS L1 Lock Time Indicator"),
-    "DF014": (UINT, 8, 0, "GPS INT,eger L1 Pseudorange Modulus Ambiguity"),
+    "DF014": (UINT, 8, 0, "GPS Integer L1 Pseudorange Modulus Ambiguity"),
     "DF015": (UINT, 8, 0.25, "GPS L1 CNR"),
     "DF016": (BIT, 2, 0, "GPS L2 Code Indicator"),
     "DF017": (INT, 14, 0.02, "GPS L2-L1 Pseudorange Difference"),


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context and, where applicable, any RTCM documentation sources you have used. List any dependencies that are required for this change.

Fix - 
In the attributes, renamed `GPS INT,eger L1 Pseudorange Modulus Ambiguity` to `GPS Integer L1 Pseudorange Modulus Ambiguity`

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- No testing required, literally fixed typo

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyrtcm/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pyrtcm/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my RTCM documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
