### PR TITLE
Rc 1.1.2

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13.0-beta.3"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13.0-rc.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13.0-beta.3"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13.0-rc.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.1.1"
+    "moduleversion": "1.1.2"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you're adding or amending rtcm payload definitions or configuration database 
 ## Coding conventions
 
 * This is open source software. Code should be as simple and transparent as possible. Favour clarity over brevity.
-* The code should be compatible with Python >=3.8.
+* The code should be compatible with Python >=3.9.
 * The core code should be as generic and reusable as possible. We endeavour to limit the amount of processing dedicated to specific rtcm message types, though this is sometimes unavoidable.
 * Avoid external library dependencies unless there's a compelling reason not to.
 * We use and recommend [Visual Studio Code](https://code.visualstudio.com/) with the [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for development and testing.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Contributions welcome - please refer to [CONTRIBUTING.MD](https://github.com/sem
 [![PyPI version](https://img.shields.io/pypi/v/pyrtcm.svg?style=flat)](https://pypi.org/project/pyrtcm/)
 ![PyPI downloads](https://img.shields.io/pypi/dm/pyrtcm.svg?style=flat)
 
-`pyrtcm` is compatible with Python 3.8 - 3.13 and has no third-party library dependencies.
+`pyrtcm` is compatible with Python 3.9 - 3.13 and has no third-party library dependencies.
 
 In the following, `python3` & `pip` refer to the Python 3 executables. You may need to substitute `python` for `python3`, depending on your particular environment (*on Windows it's generally `python`*).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pyrtcm Release Notes
 
+### RELEASE 1.1.2
+
+CHANGES:
+
+1. Sphinx documentation and docstrings enhanced to include global constants and decodes.
+1. `socket_stream.SocketStream` class renamed to `socket_wrapper.SocketWrapper` class for clarity.
+
 ### RELEASE 1.1.1
 
 ENHANCEMENTS:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ CHANGES:
 
 1. Sphinx documentation and docstrings enhanced to include global constants and decodes.
 1. `socket_stream.SocketStream` class renamed to `socket_wrapper.SocketWrapper` class for clarity.
+1. Drop active support for Python 3.8 - now End of Life as at October 2024.
 
 ### RELEASE 1.1.1
 

--- a/docs/pyrtcm.rst
+++ b/docs/pyrtcm.rst
@@ -76,10 +76,10 @@ pyrtcm.rtcmtypes\_get\_msm module
    :undoc-members:
    :show-inheritance:
 
-pyrtcm.socket\_stream module
-----------------------------
+pyrtcm.socket\_wrapper module
+-----------------------------
 
-.. automodule:: pyrtcm.socket_stream
+.. automodule:: pyrtcm.socket_wrapper
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "RTCM3 protocol parser"
 version = "1.1.2"
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
@@ -22,7 +22,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -55,10 +54,10 @@ test = [
 ]
 
 [tool.black]
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.isort]
-py_version = 38
+py_version = 39
 profile = "black"
 
 [tool.bandit]
@@ -69,7 +68,7 @@ skips = []
 jobs = 0
 reports = "y"
 recursive = "y"
-py-version = "3.8"
+py-version = "3.9"
 fail-under = "9.8"
 fail-on = "E,F"
 clear-cache-post-run = "y"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyrtcm"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "RTCM3 protocol parser"
-version = "1.1.1"
+version = "1.1.2"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pyrtcm/__init__.py
+++ b/src/pyrtcm/__init__.py
@@ -21,6 +21,6 @@ from pyrtcm.rtcmtypes_core import *
 from pyrtcm.rtcmtypes_get import *
 from pyrtcm.rtcmtypes_get_igs import *
 from pyrtcm.rtcmtypes_get_msm import *
-from pyrtcm.socket_stream import SocketStream
+from pyrtcm.socket_wrapper import SocketWrapper
 
 version = __version__  # pylint: disable=invalid-name

--- a/src/pyrtcm/_version.py
+++ b/src/pyrtcm/_version.py
@@ -8,4 +8,4 @@ Created on 14 Feb 2022
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/pyrtcm/rtcmreader.py
+++ b/src/pyrtcm/rtcmreader.py
@@ -36,7 +36,7 @@ from pyrtcm.exceptions import (
 from pyrtcm.rtcmhelpers import calc_crc24q
 from pyrtcm.rtcmmessage import RTCMMessage
 from pyrtcm.rtcmtypes_core import ERR_LOG, ERR_RAISE, NMEA_HDR, UBX_HDR, VALCKSUM
-from pyrtcm.socket_stream import SocketStream
+from pyrtcm.socket_wrapper import SocketWrapper
 
 
 class RTCMReader:
@@ -66,7 +66,7 @@ class RTCMReader:
         """
 
         if isinstance(datastream, socket):
-            self._stream = SocketStream(datastream, bufsize=bufsize)
+            self._stream = SocketWrapper(datastream, bufsize=bufsize)
         else:
             self._stream = datastream
         self._quitonerror = quitonerror

--- a/src/pyrtcm/rtcmtypes_core.py
+++ b/src/pyrtcm/rtcmtypes_core.py
@@ -34,18 +34,34 @@ NMEA_HDR = [
     b"$W",
 ]
 UBX_HDR = b"\xb5\x62"
+"""UBX message header"""
 RTCM_HDR = b"\xd3"
-NMEA_PROTOCOL = 1
-UBX_PROTOCOL = 2
-RTCM3_PROTOCOL = 4
+"""RTCM3 message header"""
 GET = 0
+"""GET (receive, response) message types"""
 SET = 1
+"""SET (command) message types"""
 POLL = 2
+"""POLL (query) message types"""
+SETPOLL = 3
+"""SETPOLL (SET or POLL) message types"""
 VALNONE = 0
+"""Do not validate checksum"""
 VALCKSUM = 1
+"""Validate checksum"""
+NMEA_PROTOCOL = 1
+"""NMEA Protocol"""
+UBX_PROTOCOL = 2
+"""UBX Protocol"""
+RTCM3_PROTOCOL = 4
+"""RTCM3 Protocol"""
 ERR_RAISE = 2
+"""Raise error and quit"""
 ERR_LOG = 1
+"""Log errors"""
 ERR_IGNORE = 0
+"""Ignore errors"""
+
 NA = "N/A"
 
 NSAT = "NSat"
@@ -892,9 +908,11 @@ GNSSMAP = {
     "112": ("BEIDOU", "DF427"),
     "113": ("NAVIC", "DF546"),
 }
+"""Map of MSM message identity prefix to GNSS name & epoch attribute name"""
 
 # map of 4076_201 coefficients
 COEFFS = {
     0: ("IDF039", "Cosine Coefficients"),
     1: ("IDF040", "Sine Coefficients"),
 }
+"""Map of 4076_01 message coefficient data attributes"""

--- a/src/pyrtcm/socket_wrapper.py
+++ b/src/pyrtcm/socket_wrapper.py
@@ -1,5 +1,5 @@
 """
-socket_stream class.
+socket_wrapper class.
 
 A skeleton socket wrapper which provides basic stream-like
 read(bytes) and readline() methods.
@@ -19,7 +19,7 @@ Created on 4 Apr 2022
 from socket import socket
 
 
-class SocketStream:
+class SocketWrapper:
     """
     socket stream class.
     """


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

1. Sphinx documentation and docstrings enhanced to include global constants and decodes.
1. `socket_stream.SocketStream` class renamed to `socket_wrapper.SocketWrapper` class for clarity.
1. Drop active support for Python 3.8 - now End of Life as at October 2024.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyrtcm/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pyrtcm/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my RTCM documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
