### PR TITLE
RC 1.1.8

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # pyrtcm Release Notes
 
+### RELEASE 1.1.8
+
+1. Address issue [#82](https://github.com/semuconsulting/pyrtcm/issues/82).
+
 ### RELEASE 1.1.7
 
 1. Internal streamlining of RTCMReader - no functional changes.

--- a/src/pyrtcm/_version.py
+++ b/src/pyrtcm/_version.py
@@ -8,4 +8,4 @@ Created on 14 Feb 2022
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"

--- a/src/pyrtcm/rtcmreader.py
+++ b/src/pyrtcm/rtcmreader.py
@@ -159,10 +159,13 @@ class RTCMReader:
         :param bytes hdr: first 2 bytes of RTCM3 header
         :return: tuple of (raw_data as bytes, parsed_stub as RTCMMessage)
         :rtype: tuple
+        :raises: RTCMStreamError
         """
 
         hdr3 = self._read_bytes(1)
         size = (hdr[1] << 8) | hdr3[0]
+        if size == 0:
+            raise RTCMStreamError(f"Invalid payload size {size} bytes")
         payload = self._read_bytes(size)
         crc = self._read_bytes(3)
         raw_data = hdr + hdr3 + payload + crc


### PR DESCRIPTION
# pyrtcm Pull Request Template

## Description

1. Raise RTCMStreamError if payload length == 0, rather than treat as EOF.

Fixes #82

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tests added to test_stream.py

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyrtcm/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pyrtcm/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my RTCM documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
